### PR TITLE
fix(personnages): éliminer Meryn Trant de la liste TODO et ajouter da…

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -1,1 +1,2 @@
 Joffrey Baratheon (ce n'est pas Arya qui l'a empoisonné)
+Meryn Trant (Éliminé par Arya)

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
 Cersei Lannister
 La Montagne
-Meryn Trant


### PR DESCRIPTION
- Ajout de La Montagne et Meryn Trant dans la liste des personnages à éliminer.
- Joffrey Baratheon a été retiré de la liste TODO après sa mort, et ajouté à DONE, en précisant que ce n’est pas Arya qui l’a empoisonné.
- Meryn Trant a été éliminé de la liste TODO et ajouté à DONE suite à son élimination par Arya.

Cette pull request finalise la mise à jour de la liste des personnes qu’Arya a éliminées.
